### PR TITLE
build: release job에서 semantic-release 관련 기능 사용을 위해 모듈 설치 스텝 추가(#1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+      # 의존성 설치
+      - name: Install dependencies
+        run: pnpm install
 
       # 빌드 아티팩트 다운로드
       - name: Download Build Artifacts
@@ -76,4 +79,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} # GitHub 권한 토큰
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # NPM 배포 토큰
-        run: npx semantic-release
+        run: pnpm run release

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node bin/cli.js",
     "clean": "rimraf bin",
     "build": "pnpm clean && rollup -c rollup.config.js --bundleConfigAsCjs",
+    "release": "semantic-release",
     "test": "jest",
     "test:watch": "jest --watch",
     "prepare": "husky"


### PR DESCRIPTION
## [작업 내용]

1. semantic-release 관련 기능 사용을 위한 모듈 설치 스텝 추가
2. release할 때 npx semantic-release에서 pnpm run release로 변경

```js
"scripts": {
    //...
    "release": "semantic-release",
    //...
  },
```