### PR TITLE
build: semantic-release 실행을 위한 CI 내 권한 설정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main # main 브랜치에 푸시될 때 실행
 
+permissions:
+  contents: read # for checkout
+
 jobs:
   build:
     name: Build CLI
@@ -47,6 +50,11 @@ jobs:
     strategy:
       matrix:
         node-version: [22]
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
 
     # 빌드 작업이 성공한 후 실행
     needs: build

--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
     "semantic-release": "^24.2.1",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/holim0/heeje-cli.git"
   }
 }


### PR DESCRIPTION
## [작업 내용]

1. Github actions 내에서 semantic-release 사용을 위한 권한 설정

- 참고: https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions