### PR TITLE
fix: bin/cli.js가 확실하게 배포 대상이 되도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "heeje": "bin/cli.js"
   },
   "files": [
-    "bin"
+    "bin/cli.js"
   ],
   "keywords": [],
   "author": "holim0",


### PR DESCRIPTION
## [작업 내용]

### 1. cli.js 배포되도록 수정
- package.json 내 files 옵션에 bin/cli.js 명시
- 배포를 위해 커밋 타입은 fix 설정