### PR TITLE
fix: 빌드 파일 경로 수정

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import typescript from 'rollup-plugin-typescript2'
 export default {
   input: 'src/index.ts',
   output: {
-    dir: 'bin/cli.js',
+    file: 'bin/cli.js',
     format: 'cjs',
     banner: '#!/usr/bin/env node',
   },


### PR DESCRIPTION
## [이슈 사항]

bin/cli.js/index.js로 생성되고 배포되고 있음

<img width="873" alt="스크린샷 2025-01-31 오후 11 57 29" src="https://github.com/user-attachments/assets/957aaa05-7340-40fd-8bbf-471a36a722bf" />

## [작업 내용]

### 1. 빌드 파일 경로 수정
- bin/cil.js로 빌드 파일 생성되도록 수정
- rollup 설정 내 output.file 설정 기반으로 빌드 파일 생성되도록 변경
```js
output: {
    file: 'bin/cli.js',
    format: 'cjs',
    banner: '#!/usr/bin/env node',
  }
```


